### PR TITLE
Docker Image Documentation

### DIFF
--- a/docker/epics-base/Dockerfile
+++ b/docker/epics-base/Dockerfile
@@ -33,9 +33,6 @@ RUN apk --no-cache add --virtual .build-deps cmake bash git g++ make perl-dev re
 # Copy additional files to image filesystem
 COPY copyroot/ /
 
-# Force all interactive shells to load profile (this is only for "--entrypoint sh" overrides)
-ENV ENV=/etc/profile
-
 # Entering via init.sh ensures environment is sourced and passed in command executed via /init
 ENTRYPOINT ["/init.sh"]
 

--- a/docker/epics-base/Dockerfile
+++ b/docker/epics-base/Dockerfile
@@ -21,18 +21,18 @@ RUN apk --no-cache add --virtual .build-deps cmake bash git g++ make perl-dev re
     && make clean \
 \
     && cd / \
-    && git clone https://github.com/krallin/tini \
-    && cd /tini \
+    && git clone --depth=1 https://github.com/krallin/tini /tini-src \
+    && cd /tini-src \
     && cmake . \
     && make \
-    && mv tini-static /init \
-    && rm -rf /tini \
+    && mv tini-static /tini \
+    && rm -rf /tini-src \
 \
     && apk del --purge .build-deps
 
 # Copy additional files to image filesystem
 COPY copyroot/ /
 
-# Entering via init.sh ensures environment is sourced and passed in command executed via /init
+# Entering via init.sh ensures environment is sourced and passed in command executed via /tini
 ENTRYPOINT ["/init.sh"]
 

--- a/docker/epics-base/README.md
+++ b/docker/epics-base/README.md
@@ -91,3 +91,5 @@ ENTRYPOINT ["/init.sh", "python"]
 
 This will create an image that drops straight into a python shell, with the environment already set up by sourcing `/etc/profile`, `/etc/profile.d/01-epics-base.sh` and `/etc/profile.d/10-setup-environment.sh` in that order.
 
+For a real-world example, see [dmscid/epics-gateway](https://hub.docker.com/r/dmscid/epics-gateway/).
+

--- a/docker/epics-base/README.md
+++ b/docker/epics-base/README.md
@@ -1,0 +1,91 @@
+# EPICS base image
+
+EPICS is the [Experimental Physics and Industrial Control System](http://www.aps.anl.gov/epics/).
+
+This image contains "EPICS base", the core EPICS software. 
+
+The purpose of this image is primarily to be used as a base for other images to build upon.
+
+This image itself is based on [Alpine](https://hub.docker.com/_/alpine/), to minimize image size and overhead.
+
+
+## Image layout and contents
+
+`/EPICS/base` contains both a build and the source of EPICS base.
+
+`/etc/profile.d/01-epics-base.sh` sets up the environment as follows:
+```sh
+EPICS_HOST_ARCH="linux-x86_64"
+EPICS_BASE="/EPICS/base"
+EPICS_CA_ADDR_LIST="127.0.0.1"
+EPICS_CA_AUTO_ADDR_LIST="NO"
+EPICS_CAS_INTF_ADDR_LIST="${ETHERNET_IPS}"
+
+PATH="${EPICS_BASE}/bin/${EPICS_HOST_ARCH}:${PATH}"
+```
+
+`/init` and `/init.sh` provide a minimalistic init system, which is described in the next section.
+
+
+## INIT System
+
+Docker containers lack an init or supervisor system by default. This leads to issues with rampant zombie processes and signals sent to the container not being passed through as expected. These issues are described in detail [here](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/) and [here](http://blog.dscpl.com.au/2015/12/issues-with-running-as-pid-1-in-docker.html).
+
+Additionally, since...
+
+1) The `ENV` directive in Dockerfiles does not currently support variable values
+2) `/etc/profile` and `~/.profile` will not be sourced unless you explictly start a login shell
+3) `/etc/bash.bashrc` and `~/.bashrc` will not be sourced unless you run `bash` in interactive but not login mode
+
+... it can be quite difficult to reliably ensure environment variables are correctly set up with values that must be determined at runtime (such as a variable IP or hostname).
+
+To resolve these issues, this image uses a combination of [tini](https://github.com/krallin/tini) (a tiny init system that solves the zombie and signal issues) and an `/init.sh` script (that sources `/etc/profile` and ensures tini is launched correctly). This script is used as the `ENTRYPOINT` of this image, and most derived images should do the same.
+
+The script has the following usage:
+`/init.sh [command [arguments]]`
+
+This will do the following:
+- `/etc/profile` is `source`d to set up the environment (which in turn `source`s `/etc/profile.d/*.sh`)
+- `[command]` is run with `[arguments]`, via tini (`/init -s -g`)
+- If no command was provided, `/bin/sh` is used as a default
+- Assuming the script is run as the `ENTRYPOINT` or `CMD`, tini will have PID 1 so that it will receive any signals the container receives from the host
+- tini will reap child processes so they don't turn into zombies and forward any signals it receives to all child processes
+
+The init script (or any `ENTRYPOINT`) may be circumvented using the `--entrypoint` argument of `docker run`. When running a container like that, you can switch to "init-mode" by sourcing `init.sh`:
+```sh
+$ docker run -it --entrypoint sh dmscid/epics-base
+ac28333e09e1:/# ps aux
+PID   USER     TIME   COMMAND
+    1 root       0:00 sh
+   11 root       0:00 ps aux
+ac28333e09e1:/# . /init.sh 
+ac28333e09e1:/# ps aux
+PID   USER     TIME   COMMAND
+    1 root       0:00 /init -s -g /bin/sh
+   15 root       0:00 /bin/sh
+   19 root       0:00 ps aux
+ac28333e09e1:/# exit
+$
+```
+
+## Usage
+
+This image is intended to be used as a base image. To to extend it, create a new Dockerfile and reference it using the `FROM` directive.
+
+To make use of the provided init system, you should keep the provided `ENTRYPOINT` or use `/init.sh` as the first field if you provide a different `ENTRYPOINT`.
+
+We recommend setting up any required environment variables by providing an `/etc/profile.d/*.sh` script and following the `XY-some-name.sh` naming convention, where `XY` is a two-digit number. Since the scripts are sourced in alphabetical order, that number can be used to control execution order.
+
+Example Dockerfile:
+```
+FROM dmscid/epics-base:latest
+
+RUN apk --no-cache add python
+
+COPY 10-setup-environment.sh /etc/profile.d/10-setup-environment.sh
+
+ENTRYPOINT ["/init.sh", "python"]
+```
+
+This will create an image that drops straight into a python shell, with the environment set up by sourcing `/etc/profile`, `/etc/profile.d/01-epics-base.sh` and `/etc/profile.d/10-setup-environment.sh` in that order.
+

--- a/docker/epics-base/README.md
+++ b/docker/epics-base/README.md
@@ -9,8 +9,8 @@ The purpose of this image is primarily to be used as a base for other images to 
 This image itself is based on [Alpine](https://hub.docker.com/_/alpine/), to minimize image size and overhead.
 
 Availability:
-- GitHub: https://github.com/DMSC-Instrument-Data/plankton-misc/tree/master/docker/epics-base
-- DockerHub: https://hub.docker.com/r/dmscid/epics-base/
+- [GitHub](https://github.com/DMSC-Instrument-Data/plankton-misc/tree/master/docker/epics-base)
+- [DockerHub](https://hub.docker.com/r/dmscid/epics-base/)
 
 
 ## Image Layout and Contents
@@ -47,10 +47,10 @@ This will do the following:
 - `/etc/profile` is `source`d to set up the environment (which in turn `source`s `/etc/profile.d/*.sh`)
 - `[command]` is run with `[arguments]`, via tini (`/init -s -g`)
 - If no command was provided, `/bin/sh` is used as a default
-- Assuming the script is run as the `ENTRYPOINT` or `CMD`, tini will have PID 1 so that it will receive any signals the container receives from the host
+- Assuming the script is run as the `ENTRYPOINT` or `CMD`, or by a shell that is PID 1, tini will have PID 1 so that it will receive any signals the container receives from the host
 - tini will reap child processes so they don't turn into zombies and forward any signals it receives to all child processes
 
-The init script (or any `ENTRYPOINT`) may be circumvented using the `--entrypoint` argument of `docker run`. When running a container like that, you can switch to "init-mode" by sourcing `init.sh`:
+The init script (or any `ENTRYPOINT`) may be circumvented using the `--entrypoint` argument of `docker run`. When running a container like that, you can switch to "init mode" by sourcing `init.sh`:
 ```sh
 $ docker run -it --entrypoint sh dmscid/epics-base
 / # ps aux

--- a/docker/epics-base/README.md
+++ b/docker/epics-base/README.md
@@ -4,7 +4,7 @@ EPICS is the [Experimental Physics and Industrial Control System](http://www.aps
 
 This image contains build and source of "EPICS base" version R3.14.12.5, the core EPICS software.
 
-The purpose of this image is primarily to be used as a base for other images to build upon.
+The purpose of this image is to provide a bare-bones, minimalistic EPICS base for other images to build upon.
 
 This image itself is based on [Alpine](https://hub.docker.com/_/alpine/), to minimize image size and overhead.
 

--- a/docker/epics-base/README.md
+++ b/docker/epics-base/README.md
@@ -8,9 +8,10 @@ The purpose of this image is primarily to be used as a base for other images to 
 
 This image itself is based on [Alpine](https://hub.docker.com/_/alpine/), to minimize image size and overhead.
 
-Availability:
+Resources:
 - [GitHub](https://github.com/DMSC-Instrument-Data/plankton-misc/tree/master/docker/epics-base)
 - [DockerHub](https://hub.docker.com/r/dmscid/epics-base/)
+- [Dockerfile](https://github.com/DMSC-Instrument-Data/plankton-misc/blob/master/docker/epics-base/Dockerfile)
 
 
 ## Image Layout and Contents

--- a/docker/epics-base/README.md
+++ b/docker/epics-base/README.md
@@ -2,7 +2,7 @@
 
 EPICS is the [Experimental Physics and Industrial Control System](http://www.aps.anl.gov/epics/).
 
-This image contains build and source of "EPICS base" version R3.14.12.5, the core EPICS software.
+This image contains source and build of "EPICS base" version R3.14.12.5, the core EPICS software.
 
 The purpose of this image is to provide a bare-bones, minimalistic EPICS base for other images to build upon.
 
@@ -14,16 +14,40 @@ Resources:
 - [Dockerfile](https://github.com/DMSC-Instrument-Data/plankton-misc/blob/master/docker/epics-base/Dockerfile)
 
 
-## Image Layout and Contents
+## Image Layout
 
-`/EPICS/base/` contains both a build and the source of EPICS base.
+Location | Contents
+-------- | --------
+`/EPICS/base/` | EPICS base source and build
+`/etc/profile.d/01-epics-base.sh` | Sets up environment variables for serving EPICS CA ([link](ttps://github.com/DMSC-Instrument-Data/plankton-misc/blob/master/docker/epics-base/copyroot/etc/profile.d/01-epics-base.sh))
+`/tini` and `/init.sh` | Minimalistic init system, which is described in a section below.
 
-[`/etc/profile.d/01-epics-base.sh`](https://github.com/DMSC-Instrument-Data/plankton-misc/blob/master/docker/epics-base/copyroot/etc/profile.d/01-epics-base.sh) sets up environment variables for serving EPICS CA.
 
-`/tini` and `/init.sh` provide a minimalistic init system, which is described in the next section.
+## Usage
+
+This image is intended to be used as a base image. To to extend it, create a new Dockerfile and reference it using the `FROM` directive.
+
+To make use of the provided init system, you should keep the provided `ENTRYPOINT` or use ensure you use `/init.sh` as the first field when defining your own `ENTRYPOINT`.
+
+We recommend setting up any required environment variables by providing an `/etc/profile.d/*.sh` script and following the `XY-some-name.sh` naming convention, where `XY` is a two-digit number. Since the scripts are sourced in alphabetical order, that number can be used to control execution order.
+
+Example Dockerfile:
+```dockerfile
+FROM dmscid/epics-base:latest
+
+RUN apk --no-cache add python
+
+COPY 10-setup-environment.sh /etc/profile.d/10-setup-environment.sh
+
+ENTRYPOINT ["/init.sh", "python"]
+```
+
+This will create an image that drops straight into a python shell, with the environment already set up by sourcing `/etc/profile`, `/etc/profile.d/01-epics-base.sh` and `/etc/profile.d/10-setup-environment.sh` in that order.
+
+For a real-world example, see [dmscid/epics-gateway](https://hub.docker.com/r/dmscid/epics-gateway/).
 
 
-## INIT System
+## Init System
 
 Docker containers lack an init or supervisor system by default. This leads to issues with rampant root zombie processes and signals sent to the container not being passed through as expected. 
 
@@ -37,7 +61,7 @@ Additionally, since...
 
 ... it can be tricky to reliably ensure environment variables are correctly set up with values that must be determined at runtime (such as a variable IP or hostname).
 
-To resolve these issues, this image provides a combination of [tini](https://github.com/krallin/tini) (a tiny init system that solves the zombie and signal issues) and an `/init.sh` script (that sources `/etc/profile` and ensures tini is launched correctly). This script is used as the `ENTRYPOINT` of this image, and most derived images should do the same.
+To resolve these issues, this image provides a combination of [tini](https://github.com/krallin/tini) and an `/init.sh` script. Tini is a tiny init system that solves the zombie and signal issues. The `init.sh` script sources `/etc/profile` and ensures tini is launched correctly. This script is used as the `ENTRYPOINT` of this image, and derived images are encouraged to follow suit.
 
 The script has the following usage:
 ```
@@ -68,28 +92,4 @@ ac28333e09e1:/# exit
 $
 ```
 Note that `/tini` has replaced `sh` as the PID 1 process, and you are now in a new shell (which defaulted to `/bin/sh` because no parameters were passed to `/init.sh`). Nevertheless, a single `exit` shuts down the container since the old shell is gone and /tini shuts down when its child process does.
-
-
-## Usage
-
-This image is intended to be used as a base image. To to extend it, create a new Dockerfile and reference it using the `FROM` directive.
-
-To make use of the above init system, you should keep the provided `ENTRYPOINT` or use `/init.sh` as the first field if you want to provide a different `ENTRYPOINT`.
-
-We recommend setting up any required environment variables by providing an `/etc/profile.d/*.sh` script and following the `XY-some-name.sh` naming convention, where `XY` is a two-digit number. Since the scripts are sourced in alphabetical order, that number can be used to control execution order.
-
-Example Dockerfile:
-```dockerfile
-FROM dmscid/epics-base:latest
-
-RUN apk --no-cache add python
-
-COPY 10-setup-environment.sh /etc/profile.d/10-setup-environment.sh
-
-ENTRYPOINT ["/init.sh", "python"]
-```
-
-This will create an image that drops straight into a python shell, with the environment already set up by sourcing `/etc/profile`, `/etc/profile.d/01-epics-base.sh` and `/etc/profile.d/10-setup-environment.sh` in that order.
-
-For a real-world example, see [dmscid/epics-gateway](https://hub.docker.com/r/dmscid/epics-gateway/).
 

--- a/docker/epics-base/README.md
+++ b/docker/epics-base/README.md
@@ -8,22 +8,25 @@ The purpose of this image is primarily to be used as a base for other images to 
 
 This image itself is based on [Alpine](https://hub.docker.com/_/alpine/), to minimize image size and overhead.
 
-GitHub: https://github.com/DMSC-Instrument-Data/plankton-misc/tree/master/docker/epics-base
-DockerHub: https://hub.docker.com/r/dmscid/epics-base/
+Availability:
+- GitHub: https://github.com/DMSC-Instrument-Data/plankton-misc/tree/master/docker/epics-base
+- DockerHub: https://hub.docker.com/r/dmscid/epics-base/
 
 
 ## Image Layout and Contents
 
 `/EPICS/base/` contains both a build and the source of EPICS base.
 
-[`/etc/profile.d/01-epics-base.sh`](https://github.com/DMSC-Instrument-Data/plankton-misc/blob/master/docker/epics-base/copyroot/etc/profile.d/01-epics-base.sh) sets up the environment for serving EPICS CA and adds the EPICS bin folder to the `$PATH`.
+[`/etc/profile.d/01-epics-base.sh`](https://github.com/DMSC-Instrument-Data/plankton-misc/blob/master/docker/epics-base/copyroot/etc/profile.d/01-epics-base.sh) sets up environment variables for serving EPICS CA.
 
 `/init` and `/init.sh` provide a minimalistic init system, which is described in the next section.
 
 
 ## INIT System
 
-Docker containers lack an init or supervisor system by default. This leads to issues with rampant zombie processes and signals sent to the container not being passed through as expected. These issues are described in detail [here](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/) and [here](http://blog.dscpl.com.au/2015/12/issues-with-running-as-pid-1-in-docker.html).
+Docker containers lack an init or supervisor system by default. This leads to issues with rampant root zombie processes and signals sent to the container not being passed through as expected. 
+
+These issues are described in detail [here](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/) and [here](http://blog.dscpl.com.au/2015/12/issues-with-running-as-pid-1-in-docker.html).
 
 Additionally, since...
 
@@ -31,12 +34,14 @@ Additionally, since...
 2. `/etc/profile` and `~/.profile` will not be sourced unless you explictly start a login shell
 3. `/etc/bash.bashrc` and `~/.bashrc` will not be sourced unless you run `bash` in interactive but not login mode
 
-... it can be quite difficult to reliably ensure environment variables are correctly set up with values that must be determined at runtime (such as a variable IP or hostname).
+... it can be tricky to reliably ensure environment variables are correctly set up with values that must be determined at runtime (such as a variable IP or hostname).
 
-To resolve these issues, this image uses a combination of [tini](https://github.com/krallin/tini) (a tiny init system that solves the zombie and signal issues) and an `/init.sh` script (that sources `/etc/profile` and ensures tini is launched correctly). This script is used as the `ENTRYPOINT` of this image, and most derived images should do the same.
+To resolve these issues, this image provides a combination of [tini](https://github.com/krallin/tini) (a tiny init system that solves the zombie and signal issues) and an `/init.sh` script (that sources `/etc/profile` and ensures tini is launched correctly). This script is used as the `ENTRYPOINT` of this image, and most derived images should do the same.
 
 The script has the following usage:
-`/init.sh [command [arguments]]`
+```
+/init.sh [command [arguments]]
+```
 
 This will do the following:
 - `/etc/profile` is `source`d to set up the environment (which in turn `source`s `/etc/profile.d/*.sh`)
@@ -48,25 +53,27 @@ This will do the following:
 The init script (or any `ENTRYPOINT`) may be circumvented using the `--entrypoint` argument of `docker run`. When running a container like that, you can switch to "init-mode" by sourcing `init.sh`:
 ```sh
 $ docker run -it --entrypoint sh dmscid/epics-base
-ac28333e09e1:/# ps aux
+/ # ps aux
 PID   USER     TIME   COMMAND
     1 root       0:00 sh
-   11 root       0:00 ps aux
-ac28333e09e1:/# . /init.sh 
+    7 root       0:00 ps aux
+/ # . /init.sh
 ac28333e09e1:/# ps aux
 PID   USER     TIME   COMMAND
     1 root       0:00 /init -s -g /bin/sh
-   15 root       0:00 /bin/sh
-   19 root       0:00 ps aux
+   11 root       0:00 /bin/sh
+   12 root       0:00 ps aux
 ac28333e09e1:/# exit
 $
 ```
+Note that `/init` has replaced `sh` as the PID 1 process, and you are now in a new shell (which defaulted to `/bin/sh` because no parameters were passed to `/init.sh`). Nevertheless, a single `exit` shuts down the container since the old shell is gone.
+
 
 ## Usage
 
 This image is intended to be used as a base image. To to extend it, create a new Dockerfile and reference it using the `FROM` directive.
 
-To make use of the provided init system, you should keep the provided `ENTRYPOINT` or use `/init.sh` as the first field if you provide a different `ENTRYPOINT`.
+To make use of the above init system, you should keep the provided `ENTRYPOINT` or use `/init.sh` as the first field if you want to provide a different `ENTRYPOINT`.
 
 We recommend setting up any required environment variables by providing an `/etc/profile.d/*.sh` script and following the `XY-some-name.sh` naming convention, where `XY` is a two-digit number. Since the scripts are sourced in alphabetical order, that number can be used to control execution order.
 
@@ -81,5 +88,5 @@ COPY 10-setup-environment.sh /etc/profile.d/10-setup-environment.sh
 ENTRYPOINT ["/init.sh", "python"]
 ```
 
-This will create an image that drops straight into a python shell, with the environment set up by sourcing `/etc/profile`, `/etc/profile.d/01-epics-base.sh` and `/etc/profile.d/10-setup-environment.sh` in that order.
+This will create an image that drops straight into a python shell, with the environment already set up by sourcing `/etc/profile`, `/etc/profile.d/01-epics-base.sh` and `/etc/profile.d/10-setup-environment.sh` in that order.
 

--- a/docker/epics-base/README.md
+++ b/docker/epics-base/README.md
@@ -1,28 +1,22 @@
-# EPICS base image
+# EPICS Base Image
 
 EPICS is the [Experimental Physics and Industrial Control System](http://www.aps.anl.gov/epics/).
 
-This image contains "EPICS base", the core EPICS software. 
+This image contains build and source of "EPICS base" version R3.14.12.5, the core EPICS software.
 
 The purpose of this image is primarily to be used as a base for other images to build upon.
 
 This image itself is based on [Alpine](https://hub.docker.com/_/alpine/), to minimize image size and overhead.
 
+GitHub: https://github.com/DMSC-Instrument-Data/plankton-misc/tree/master/docker/epics-base
+DockerHub: https://hub.docker.com/r/dmscid/epics-base/
 
-## Image layout and contents
 
-`/EPICS/base` contains both a build and the source of EPICS base.
+## Image Layout and Contents
 
-`/etc/profile.d/01-epics-base.sh` sets up the environment as follows:
-```sh
-EPICS_HOST_ARCH="linux-x86_64"
-EPICS_BASE="/EPICS/base"
-EPICS_CA_ADDR_LIST="127.0.0.1"
-EPICS_CA_AUTO_ADDR_LIST="NO"
-EPICS_CAS_INTF_ADDR_LIST="${ETHERNET_IPS}"
+`/EPICS/base/` contains both a build and the source of EPICS base.
 
-PATH="${EPICS_BASE}/bin/${EPICS_HOST_ARCH}:${PATH}"
-```
+[`/etc/profile.d/01-epics-base.sh`](https://github.com/DMSC-Instrument-Data/plankton-misc/blob/master/docker/epics-base/copyroot/etc/profile.d/01-epics-base.sh) sets up the environment for serving EPICS CA and adds the EPICS bin folder to the `$PATH`.
 
 `/init` and `/init.sh` provide a minimalistic init system, which is described in the next section.
 
@@ -33,9 +27,9 @@ Docker containers lack an init or supervisor system by default. This leads to is
 
 Additionally, since...
 
-1) The `ENV` directive in Dockerfiles does not currently support variable values
-2) `/etc/profile` and `~/.profile` will not be sourced unless you explictly start a login shell
-3) `/etc/bash.bashrc` and `~/.bashrc` will not be sourced unless you run `bash` in interactive but not login mode
+1. The `ENV` directive in Dockerfiles does not currently support variable values
+2. `/etc/profile` and `~/.profile` will not be sourced unless you explictly start a login shell
+3. `/etc/bash.bashrc` and `~/.bashrc` will not be sourced unless you run `bash` in interactive but not login mode
 
 ... it can be quite difficult to reliably ensure environment variables are correctly set up with values that must be determined at runtime (such as a variable IP or hostname).
 

--- a/docker/epics-base/copyroot/init.sh
+++ b/docker/epics-base/copyroot/init.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
-# Launches passed in arguments via /init (https://github.com/krallin/tini)
+# Launches passed in arguments via /tini (https://github.com/krallin/tini)
 # It acts as a miniature init system to pass through signals and reap zombies.
+# Usage: . /init.sh [command [arguments]]
 
 # Set up environment
 . /etc/profile
 
-# Passed in arguments will run via init
+# First argument is command to be run via /tini
 if [ $# -gt 0 ]; then
     CMD="$1"
     shift
@@ -15,5 +16,5 @@ else
 fi
 
 # Replace this shell with passed in command and arguments, if available
-exec /init -s -g "${CMD}" "$@"
+exec /tini -s -g -- "${CMD}" "$@"
 

--- a/docker/epics-gateway/README.md
+++ b/docker/epics-gateway/README.md
@@ -1,0 +1,37 @@
+# EPICS Gateway
+
+EPICS is the [Experimental Physics and Industrial Control System](http://www.aps.anl.gov/epics/).
+
+EPICS Gateway is the [Process Variable Gateway](http://www.aps.anl.gov/epics/extensions/gateway/) extension.
+
+This image is based on [dmscid/epics-base](https://hub.docker.com/r/dmscid/epics-base/) and additionally provides [EPICS Extensions Top 2012-09-04](https://www.aps.anl.gov/epics/download/extensions/index.php) and the Gateway Extension version 2.0.5.1 with PCRE support.
+
+The purpose of this image is to provide a ready-to-use EPICS gateway that is preconfigured to allow all traffic.
+
+Among other things, this is useful for forwarding Channel Access between the `docker0` network and the host machine when using docker via DockerMachine on Windows and Mac.
+
+Resources:
+- [GitHub](https://github.com/DMSC-Instrument-Data/plankton-misc/tree/master/docker/epics-gateway)
+- [DockerHub](https://hub.docker.com/r/dmscid/epics-gateway/)
+- [Dockerfile](https://github.com/DMSC-Instrument-Data/plankton-misc/blob/master/docker/epics-gateway/Dockerfile)
+
+
+## Image Layout and Contents
+
+`/EPICS/base/` contains EPICS Base.
+
+`/EPICS/extensions/` contains EPICS Extensions Top.
+
+`/EPICS/extensions/src/gateway/` contains EPICS Gateway source.
+
+`/gateway/` is set as the Gateway home directory. It contains the access, command and pvlist files, and any logs or reports will be written here.
+
+
+## Usage
+
+The image is set up to run `gateway` as the `ENTRYPOINT`, so you can pass Gateway arguments directly through `docker run`. Generally, it should be invoked with the `--net=host` docker argument to give it full access to the network stack.
+
+The client IP (`-cip`) defaults to 172.17.255.255 by means of the `EPICS_CA_ADDR_LIST` , so the gateway
+
+
+

--- a/docker/epics-pcaspy/Dockerfile
+++ b/docker/epics-pcaspy/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache add \
 # Build latest pcaspy and cleanup
 RUN apk --no-cache add --virtual .build-deps g++ readline-dev git swig python-dev \
     && . /etc/profile \
-    && git clone --depth=1 https://github.com/paulscherrerinstitute/pcaspy.git \
+    && git clone https://github.com/paulscherrerinstitute/pcaspy.git \
     && cd /pcaspy \
     && git checkout f74a052c158688d8528a2620ce196d09f5355078 \
     && python setup.py install \

--- a/docker/epics-pcaspy/Dockerfile
+++ b/docker/epics-pcaspy/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache add \
 # Build latest pcaspy and cleanup
 RUN apk --no-cache add --virtual .build-deps g++ readline-dev git swig python-dev \
     && . /etc/profile \
-    && git clone https://github.com/paulscherrerinstitute/pcaspy.git \
+    && git clone --depth=1 https://github.com/paulscherrerinstitute/pcaspy.git \
     && cd /pcaspy \
     && git checkout f74a052c158688d8528a2620ce196d09f5355078 \
     && python setup.py install \

--- a/docker/epics-pcaspy/README.md
+++ b/docker/epics-pcaspy/README.md
@@ -1,0 +1,28 @@
+# EPICS with PCASpy
+
+EPICS is the [Experimental Physics and Industrial Control System](http://www.aps.anl.gov/epics/).
+
+PCASpy provides [Python bindings for the Portable Channel Access Server](https://pcaspy.readthedocs.io/en/latest/).
+
+This image is based on [dmscid/epics-base](https://hub.docker.com/r/dmscid/epics-base/) and additionally provides Python, Pip and PCASpy v0.6.0.
+
+The purpose of this image is primarily to be used as a base for other images to build upon.
+
+Resources:
+- [GitHub](https://github.com/DMSC-Instrument-Data/plankton-misc/tree/master/docker/epics-pcaspy)
+- [DockerHub](https://hub.docker.com/r/dmscid/epics-pcaspy/)
+- [Dockerfile](https://github.com/DMSC-Instrument-Data/plankton-misc/blob/master/docker/epics-pcaspy/Dockerfile)
+
+
+## Usage
+
+This image is intended to be used as a base image. To to extend it, create a new Dockerfile and reference it using the `FROM` directive.
+
+To make use of the init system, you should keep the provided `ENTRYPOINT` or use `/init.sh` as the first field if you want to provide a different `ENTRYPOINT`.
+
+We recommend setting up any required environment variables by providing an `/etc/profile.d/*.sh` script and following the `XY-some-name.sh` naming convention, where `XY` is a two-digit number. Since the scripts are sourced in alphabetical order, that number can be used to control execution order.
+
+See [dmscid/epics-base](https://hub.docker.com/r/dmscid/epics-base/) for details.
+
+See [dmscid/plankton](https://hub.docker.com/r/dmscid/plankton/) for a usage example.
+


### PR DESCRIPTION
This PR provides documentation for the epics-base, epics-pcaspy and epics-gateway images.

I've also manually copied this to DockerHub so that the images have a useful description there now.

Links to DockerHub pages:
https://hub.docker.com/r/dmscid/epics-base/
https://hub.docker.com/r/dmscid/epics-pcaspy/
https://hub.docker.com/r/dmscid/epics-gateway/

May want to look into automating that in the future.

Also squeezed in two minor tweaks:
- Renamed `/init` to `/tini` to be more representative and distinct from `init.sh`... calling it `/init` was a leftover from when I wasn't sure what I would be using to serve as the init system.
- Removed the ENV hack that forced all interactive shells to source /etc/profile. Doesn't feel right to force it. Especially since it would get sourced twice in many situations as a result. This way user has the choice of using `--entrypoint sh` for a clean shell and `--entrypoint /init.sh` for a shell that has sourced /etc/profile.
