### PR TITLE
Docker image fixes and optimizations

### DIFF
--- a/docker/epics-base/Dockerfile
+++ b/docker/epics-base/Dockerfile
@@ -3,30 +3,22 @@ FROM alpine:latest
 # Runtime dependencies
 RUN apk --no-cache add \
     libstdc++ \
+    tini \
     readline
 
-# Get EPICS source
-RUN mkdir /EPICS \
+# Get EPICS source -> Build -> Cleanup
+RUN apk --no-cache add --virtual .build-deps cmake git g++ make perl-dev readline-dev \
+\
+    && mkdir /EPICS \
     && cd /EPICS \
     && wget http://www.aps.anl.gov/epics/download/base/baseR3.14.12.5.tar.gz -O EPICS.tar.gz \
     && tar xzf EPICS.tar.gz \
     && mv base-*/ base/ \
-    && rm EPICS.tar.gz
-
-# Build and cleanup (EPICS + tini)
-RUN apk --no-cache add --virtual .build-deps cmake bash git g++ make perl-dev readline-dev \
+    && rm EPICS.tar.gz \
 \
     && cd /EPICS/base \
     && make -j4 CFLAGS="-DIPPORT_USERRESERVED=5000 -fPIC" CXXFLAGS="-DIPPORT_USERRESERVED=5000 -fPIC" \
     && make clean \
-\
-    && cd / \
-    && git clone --depth=1 https://github.com/krallin/tini /tini-src \
-    && cd /tini-src \
-    && cmake . \
-    && make \
-    && mv tini-static /tini \
-    && rm -rf /tini-src \
 \
     && apk del --purge .build-deps
 

--- a/docker/epics-base/README.md
+++ b/docker/epics-base/README.md
@@ -20,7 +20,7 @@ Location | Contents
 -------- | --------
 `/EPICS/base/` | EPICS base source and build
 `/etc/profile.d/01-epics-base.sh` | Sets up environment variables for serving EPICS CA ([link](ttps://github.com/DMSC-Instrument-Data/plankton-misc/blob/master/docker/epics-base/copyroot/etc/profile.d/01-epics-base.sh))
-`/tini` and `/init.sh` | Minimalistic init system, which is described in a section below.
+`/sbin/tini` and `/init.sh` | Minimalistic init system, which is described in a section below.
 
 
 ## Usage
@@ -70,7 +70,7 @@ The script has the following usage:
 
 This will do the following:
 - `/etc/profile` is `source`d to set up the environment (which in turn `source`s `/etc/profile.d/*.sh`)
-- `[command]` is run with `[arguments]`, via tini (`/tini -s -g`)
+- `[command]` is run with `[arguments]`, via tini (`/sbin/tini -s -g`)
 - If no command was provided, `/bin/sh` is used as a default
 - Assuming the script is run as the `ENTRYPOINT` or `CMD`, or by a shell that is PID 1, tini will have PID 1 so that it will receive any signals the container receives from the host
 - tini will reap child processes so they don't turn into zombies and forward any signals it receives to all child processes
@@ -85,11 +85,11 @@ PID   USER     TIME   COMMAND
 / # . /init.sh
 ac28333e09e1:/# ps aux
 PID   USER     TIME   COMMAND
-    1 root       0:00 /tini -s -g -- /bin/sh
+    1 root       0:00 /sbin/tini -s -g -- /bin/sh
    11 root       0:00 /bin/sh
    12 root       0:00 ps aux
 ac28333e09e1:/# exit
 $
 ```
-Note that `/tini` has replaced `sh` as the PID 1 process, and you are now in a new shell (which defaulted to `/bin/sh` because no parameters were passed to `/init.sh`). Nevertheless, a single `exit` shuts down the container since the old shell is gone and /tini shuts down when its child process does.
+Note that `/sbin/tini` has replaced `sh` as the PID 1 process, and you are now in a new shell (which defaulted to `/bin/sh` because no parameters were passed to `/init.sh`). Nevertheless, a single `exit` shuts down the container since the old shell is gone and tini shuts down when its child process does.
 

--- a/docker/epics-base/copyroot/init.sh
+++ b/docker/epics-base/copyroot/init.sh
@@ -16,5 +16,5 @@ else
 fi
 
 # Replace this shell with passed in command and arguments, if available
-exec /tini -s -g -- "${CMD}" "$@"
+exec /sbin/tini -s -g -- "${CMD}" "$@"
 

--- a/docker/plankton-depends/Dockerfile
+++ b/docker/plankton-depends/Dockerfile
@@ -1,16 +1,19 @@
 FROM dmscid/epics-base:latest
 
-# Runtime dependencies
+# Install runtime dependencies and cleanup
 RUN apk --no-cache add \
     libstdc++ \
     python \
     py-pip \
-    readline
+    readline \
+    && find \( -name '*.pyc' -o -name '*.pyo*' \) -exec rm -rf '{}' +
 
-# Build dependencies and cleanup
-RUN apk --no-cache add --virtual .build-deps g++ readline-dev git swig python-dev \
+# Install dependencies that require building and cleanup
+RUN apk --no-cache add --virtual .build-deps g++ swig readline-dev python-dev \
     && . /etc/profile \
     && pip install pcaspy \
     && pip install pyzmq \
+    && rm -rf /root/.cache/pip/* \
+    && find \( -name '*.pyc' -o -name '*.pyo*' \) -exec rm -rf '{}' + \
     && apk del --purge .build-deps
 

--- a/docker/plankton-depends/Dockerfile
+++ b/docker/plankton-depends/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add \
     python \
     py-pip \
     readline \
-    && find \( -name '*.pyc' -o -name '*.pyo*' \) -exec rm -rf '{}' +
+    && find \( -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' +
 
 # Install dependencies that require building and cleanup
 RUN apk --no-cache add --virtual .build-deps g++ swig readline-dev python-dev \


### PR DESCRIPTION
While concluding work on #4, noticed a couple other issues. 

Most importantly, `epics-base` was no longer building due to a change in `tini` that added a dependency (`vim` of all things).

This PR fixes this by using the new `tini` Alpine package instead of compiling from source, and improves the build process and cleanup to make the images even smaller.

The size of `plankton-depends` has dropped from ~78MB to ~56MB.
The size of `plankton` will similarly drop from ~80MB to ~57MB.
